### PR TITLE
Fixed test for julia 1.0 compat

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ using Test
             y = "abc"
             @info "hey there" x y
         end
-        logs = String(take!(io)) |> chomp
+        logs = String(take!(io)) |> chomp |> String
         @test findall("\n", logs) |> length == 0
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,8 +34,8 @@ using Test
             y = "abc"
             @info "hey there" x y
         end
-        logs = String(take!(io)) |> chomp |> String
-        @test findall("\n", logs) |> length == 0
+        logs = String(take!(io)) |> chomp
+        @test findall(x -> x == '\n', logs) |> length == 0
     end
 
     # Verify valid JSON


### PR DESCRIPTION
Apparently, the `findall` function in Julia 1.0 does not accept `SubString` in the second argument.