### PR TITLE
Use @kwdef and added docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Use the `logger` function to create new Transformer logger with the desired form
 ### Logging with timestamp
 
 ```julia
-julia> ts_fmt = TimestampTransform("yyyy-mm-dd HH:MM:SS", InjectByPrependingToMessage());
+julia> ts_fmt = TimestampTransform(format = "yyyy-mm-dd HH:MM:SS",
+                                   location = InjectByPrependingToMessage());
 
 julia> with_logger(logger(ConsoleLogger(), ts_fmt)) do
            @info "hey there"
@@ -49,7 +50,8 @@ julia> with_logger(logger(ConsoleLogger(), oneline_fmt)) do
 ```julia
 json_logger = logger(
                 SimplestLogger(),
-                TimestampTransform("yyyy-mm-dd HH:MM:SS", InjectByAddingToKwargs()),
+                TimestampTransform(format = "yyyy-mm-dd HH:MM:SS",
+                                   location = InjectByAddingToKwargs()),
                 JSONTransform(indent = 2))
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,8 @@ using Test
     # Validate timestamp is printed at the beginning of line
     let
         io = IOBuffer()
-        ts_trans = TimestampTransform("yyyy-mm-dd HH:MM:SS", InjectByPrependingToMessage())
+        ts_trans = TimestampTransform(format = "yyyy-mm-dd HH:MM:SS",
+                                      location = InjectByPrependingToMessage())
         with_logger(logger(SimplestLogger(io), ts_trans)) do
             @info "hey there"
         end
@@ -69,7 +70,7 @@ using Test
     let
         io = IOBuffer()
         js_trans = JSONTransform(indent = 2)
-        ts_trans = TimestampTransform("yyyy-mm-dd HH:MM:SS", InjectByAddingToKwargs())
+        ts_trans = TimestampTransform(format = "yyyy-mm-dd HH:MM:SS", location = InjectByAddingToKwargs())
         my_logger = logger(SimplestLogger(io), ts_trans, js_trans)
         with_logger(my_logger) do
             x = 1


### PR DESCRIPTION
- Use Base.@kwdef for Transform types (exception TimestampTransform which has a kwarg-based constructor)
- Renamed `message_label` and `level_label` as just `label`
- Added doc strings
